### PR TITLE
Feature lighter init

### DIFF
--- a/src/main/java/ar/com/synergian/wagongit/GitBackend.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitBackend.java
@@ -3,7 +3,10 @@ package ar.com.synergian.wagongit;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.log.ScmLogger;
@@ -17,6 +20,7 @@ public class GitBackend {
 	final File workDir;
 	private final String remote;
 	private final String branch;
+	private final boolean enableShallowFetch;
 
 	private final ScmLogger log;
 
@@ -40,13 +44,14 @@ public class GitBackend {
 
 	};
 
-	public GitBackend(File workDir, String remote, String branch, ScmLogger log) throws GitException {
+	public GitBackend(File workDir, String remote, String branch, ScmLogger log, boolean enableShallowFetch) throws GitException {
 		this.log = log;
 		this.remote = remote;
 		this.branch = branch;
 		this.workDir = workDir;
 		if (!this.workDir.exists())
 			throw new GitException("Invalid directory");
+		this.enableShallowFetch = enableShallowFetch;
 
 	}
 
@@ -115,8 +120,13 @@ public class GitBackend {
 				}
 			}
 
-			if (!run("fetch", new String[] { "--progress" }))
+			String[] fetchArgs = new String[] { "--progress" };
+			if (enableShallowFetch) {
+				fetchArgs = new String[] { "--progress", "--depth=1" };
+			}
+			if (!run("fetch", fetchArgs)) {
 				throw new GitException("git fetch failed");
+			}
 		}
 
 		// if remote branch doesn't exist, create new "headless".

--- a/src/main/java/ar/com/synergian/wagongit/GitBackend.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitBackend.java
@@ -3,10 +3,7 @@ package ar.com.synergian.wagongit;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.log.ScmLogger;
@@ -20,7 +17,7 @@ public class GitBackend {
 	final File workDir;
 	private final String remote;
 	private final String branch;
-	private final boolean enableShallowFetch;
+	private final boolean disableShallowFetch;
 
 	private final ScmLogger log;
 
@@ -44,14 +41,14 @@ public class GitBackend {
 
 	};
 
-	public GitBackend(File workDir, String remote, String branch, ScmLogger log, boolean enableShallowFetch) throws GitException {
+	public GitBackend(File workDir, String remote, String branch, ScmLogger log, boolean disableShallowFetch) throws GitException {
 		this.log = log;
 		this.remote = remote;
 		this.branch = branch;
 		this.workDir = workDir;
 		if (!this.workDir.exists())
 			throw new GitException("Invalid directory");
-		this.enableShallowFetch = enableShallowFetch;
+		this.disableShallowFetch = disableShallowFetch;
 
 	}
 
@@ -120,9 +117,9 @@ public class GitBackend {
 				}
 			}
 
-			String[] fetchArgs = new String[] { "--progress" };
-			if (enableShallowFetch) {
-				fetchArgs = new String[] { "--progress", "--depth=1" };
+			String[] fetchArgs = new String[] { "--progress", "--depth=1" };
+			if (disableShallowFetch) {
+				fetchArgs = new String[] { "--progress" };
 			}
 			if (!run("fetch", fetchArgs)) {
 				throw new GitException("git fetch failed");

--- a/src/main/java/ar/com/synergian/wagongit/GitWagon.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitWagon.java
@@ -119,7 +119,8 @@ public class GitWagon extends StreamWagon {
 				}
 
 				String path = remote;
-				if (permanentRoot != null && !"".equals(permanentRoot)) {
+				boolean permanentRootIsDefined = (permanentRoot != null && !"".equals(permanentRoot));
+				if (permanentRootIsDefined) {
 					path = permanentRoot;
 				}
 				File workDir = Utils.createCheckoutDirectory(path);
@@ -127,7 +128,7 @@ public class GitWagon extends StreamWagon {
 				if (!workDir.exists() || !workDir.isDirectory() || !workDir.canWrite())
 					throw new ConnectionException("Unable to create working directory");
 
-				if (safeCheckout)
+				if (safeCheckout && !permanentRootIsDefined)
 					FileUtils.cleanDirectory(workDir);
 
 				git = new GitBackend(workDir, remote, branch, log, disableShallowFetch);

--- a/src/main/java/ar/com/synergian/wagongit/GitWagon.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitWagon.java
@@ -28,6 +28,7 @@ public class GitWagon extends StreamWagon {
 	private final boolean safeCheckout = Utils.getBooleanEnvironmentProperty("wagon.git.safe.checkout");
 	private final boolean skipEmptyCommit = Utils.getBooleanEnvironmentProperty("wagon.git.skip.empty.commit");
 	private final boolean enableShallowFetch = Utils.getBooleanEnvironmentProperty("wagon.git.enable.shallow.fetch");
+	private final String permanentRoot = Utils.getStringEnvironmentProperty("wagon.git.permanent.root");
 
 	private final ScmLogger log = new GitWagonLog(debug);
 
@@ -117,7 +118,12 @@ public class GitWagon extends StreamWagon {
 					remote = url.substring(i + 3, url.length());
 				}
 
-				File workDir = Utils.createCheckoutDirectory(remote);
+				File workDir;
+				if (permanentRoot != null && !"".equals(permanentRoot)) {
+					workDir = Utils.createCheckoutDirectory(permanentRoot, true);
+				} else {
+					workDir = Utils.createCheckoutDirectory(remote, false);
+				}
 
 				if (!workDir.exists() || !workDir.isDirectory() || !workDir.canWrite())
 					throw new ConnectionException("Unable to create working directory");

--- a/src/main/java/ar/com/synergian/wagongit/GitWagon.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitWagon.java
@@ -27,7 +27,7 @@ public class GitWagon extends StreamWagon {
 	private final boolean debug = Utils.getBooleanEnvironmentProperty("wagon.git.debug");
 	private final boolean safeCheckout = Utils.getBooleanEnvironmentProperty("wagon.git.safe.checkout");
 	private final boolean skipEmptyCommit = Utils.getBooleanEnvironmentProperty("wagon.git.skip.empty.commit");
-	private final boolean enableShallowFetch = Utils.getBooleanEnvironmentProperty("wagon.git.enable.shallow.fetch");
+	private final boolean disableShallowFetch = Utils.getBooleanEnvironmentProperty("wagon.git.disable.shallow.fetch");
 	private final String permanentRoot = Utils.getStringEnvironmentProperty("wagon.git.permanent.root");
 
 	private final ScmLogger log = new GitWagonLog(debug);
@@ -118,12 +118,11 @@ public class GitWagon extends StreamWagon {
 					remote = url.substring(i + 3, url.length());
 				}
 
-				File workDir;
+				String path = remote;
 				if (permanentRoot != null && !"".equals(permanentRoot)) {
-					workDir = Utils.createCheckoutDirectory(permanentRoot, true);
-				} else {
-					workDir = Utils.createCheckoutDirectory(remote, false);
+					path = permanentRoot;
 				}
+				File workDir = Utils.createCheckoutDirectory(path);
 
 				if (!workDir.exists() || !workDir.isDirectory() || !workDir.canWrite())
 					throw new ConnectionException("Unable to create working directory");
@@ -131,7 +130,7 @@ public class GitWagon extends StreamWagon {
 				if (safeCheckout)
 					FileUtils.cleanDirectory(workDir);
 
-				git = new GitBackend(workDir, remote, branch, log, enableShallowFetch);
+				git = new GitBackend(workDir, remote, branch, log, disableShallowFetch);
 				git.pullAll();
 			} catch (Exception e) {
 				throw new ConnectionException("Unable to pull git repository: " + e.getMessage(), e);

--- a/src/main/java/ar/com/synergian/wagongit/GitWagon.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitWagon.java
@@ -27,6 +27,7 @@ public class GitWagon extends StreamWagon {
 	private final boolean debug = Utils.getBooleanEnvironmentProperty("wagon.git.debug");
 	private final boolean safeCheckout = Utils.getBooleanEnvironmentProperty("wagon.git.safe.checkout");
 	private final boolean skipEmptyCommit = Utils.getBooleanEnvironmentProperty("wagon.git.skip.empty.commit");
+	private final boolean enableShallowFetch = Utils.getBooleanEnvironmentProperty("wagon.git.enable.shallow.fetch");
 
 	private final ScmLogger log = new GitWagonLog(debug);
 
@@ -124,7 +125,7 @@ public class GitWagon extends StreamWagon {
 				if (safeCheckout)
 					FileUtils.cleanDirectory(workDir);
 
-				git = new GitBackend(workDir, remote, branch, log);
+				git = new GitBackend(workDir, remote, branch, log, enableShallowFetch);
 				git.pullAll();
 			} catch (Exception e) {
 				throw new ConnectionException("Unable to pull git repository: " + e.getMessage(), e);

--- a/src/main/java/ar/com/synergian/wagongit/Utils.java
+++ b/src/main/java/ar/com/synergian/wagongit/Utils.java
@@ -11,15 +11,14 @@ public final class Utils {
 	private Utils() {
 	}
 
-	public static File createCheckoutDirectory(String path, boolean isPermanent) throws GitException {
+	public static File createCheckoutDirectory(String path) throws GitException {
 		File dir;
-		if (isPermanent) {
-			dir = new File(path);
-		} else {
+		if (path.endsWith(".git")) {
 			dir = new File(System.getProperty("java.io.tmpdir"), "wagon-git-" + hashPath(path));
+		} else {
+			dir = new File(path);
 		}
 		dir.mkdirs();
-
 		return dir;
 	}
 

--- a/src/main/java/ar/com/synergian/wagongit/Utils.java
+++ b/src/main/java/ar/com/synergian/wagongit/Utils.java
@@ -12,7 +12,7 @@ public final class Utils {
 	}
 
 	public static File createCheckoutDirectory(String path) throws GitException {
-
+		// FIXME use predefined folder
 		File dir = new File(System.getProperty("java.io.tmpdir"), "wagon-git-" + hashPath(path));
 		dir.mkdirs();
 

--- a/src/main/java/ar/com/synergian/wagongit/Utils.java
+++ b/src/main/java/ar/com/synergian/wagongit/Utils.java
@@ -11,9 +11,13 @@ public final class Utils {
 	private Utils() {
 	}
 
-	public static File createCheckoutDirectory(String path) throws GitException {
-		// FIXME use predefined folder
-		File dir = new File(System.getProperty("java.io.tmpdir"), "wagon-git-" + hashPath(path));
+	public static File createCheckoutDirectory(String path, boolean isPermanent) throws GitException {
+		File dir;
+		if (isPermanent) {
+			dir = new File(path);
+		} else {
+			dir = new File(System.getProperty("java.io.tmpdir"), "wagon-git-" + hashPath(path));
+		}
 		dir.mkdirs();
 
 		return dir;
@@ -55,8 +59,10 @@ public final class Utils {
 	}
 
 	public static boolean getBooleanEnvironmentProperty(String key) {
-
 		return Boolean.parseBoolean(System.getProperty(key, "false"));
+	}
 
+	public static String getStringEnvironmentProperty(String key) {
+		return System.getProperty(key, null);
 	}
 }

--- a/src/site/apt/troubleshooting.apt
+++ b/src/site/apt/troubleshooting.apt
@@ -9,6 +9,8 @@ Troubleshooting
 mvn clean deploy site-deploy -DperformRelease -Dwagon.git.safe.checkout=true
 +--
 
+   Notice : this parameter is override to false when <<<wagon.git.permanent.root>>> is set.
+
 * Debug mode
 
 

--- a/src/site/apt/usage-advanced.vm
+++ b/src/site/apt/usage-advanced.vm
@@ -1,0 +1,25 @@
+Advanced usage
+
+
+
+* Permanent maven repository
+
+    By default, wagon-git will store the maven repository's remote clone inside temporary files.
+    If you want to change the repository to a permanent location, you can define the path: 
+
++--
+mvn deploy -Dwagon.git.permanent.root="/path/to/a/folder/where/to/store/maven/repo"
++--
+
+
+
+* Lighter initialization
+
+    After a while, the remote maven repository can become quite heavy, especially with all snapshots stored in Git history.
+    We don't usually need all Git history, we only need the latest HEAD.
+    By default, wagont-git will only retrieve the latest HEAD of a branch.
+    If you're using an old version of Git (which doesn't support shallow clone) or if you want to retrieve all the Git history, you can disable the lighter initialization:
+
++--
+mvn deploy -Dwagon.git.disable.shallow.fetch=true
++--

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -67,6 +67,9 @@
 				name="Bitbucket usage"
 				href="bitbucket.html" />
 			<item
+				name="Advanced configuration"
+				href="usage-advanced.html" />
+			<item
 				name="Troubleshooting"
 				href="troubleshooting.html" />
 			<item


### PR DESCRIPTION
Here is a PR for #43.
It's a work in progress (it needs testing), but i want to show you where I was going as soon as possible.
There is 2 new properties :

1. wagon.git.enable.shallow.fetch : to only retrieve the head of a branch
1. wagon.git.permanent.root : to use a well-known root directory (one not
temporary) for git clones