### PR TITLE
to support bitbucket raw content url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,15 @@
 
 	<groupId>ar.com.synergian</groupId>
 	<artifactId>wagon-git</artifactId>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.3.1</version>
 	<packaging>jar</packaging>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>synergian-repo</id>
+			<url>https://raw.github.com/synergian/wagon-git/releases</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<name>wagon-git</name>
 
@@ -22,6 +29,10 @@
 		<developer>
 			<name>Martin Schonaker</name>
 			<email>mschonaker@gmail.com</email>
+		</developer>
+		<developer>
+			<name>Doowoong Lee</name>
+			<email>innocentevil0914@gmail.com</email>
 		</developer>
 	</developers>
 	<description>A Maven component (a wagon provider) that enables deploying artifacts in remote Git SCM repositories.</description>
@@ -60,6 +71,13 @@
 	</dependencies>
 
 	<build>
+		<extensions>
+			<extension>
+				<groupId>ar.com.synergian</groupId>
+				<artifactId>wagon-git</artifactId>
+				<version>0.2.5</version>
+			</extension>
+		</extensions>
 		<plugins>
 			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
@@ -140,7 +158,7 @@
 
 	<scm>
 		<url>https://github.com/synergian/wagon-git</url>
-		<connection>scm:git:ssh://git@github.com/synergian/wagon-git.git</connection>
+		<connection>scm:git:ssh://git@github.com:fritzprix/wagon-git.git</connection>
 	  <tag>HEAD</tag>
   </scm>
 
@@ -148,17 +166,17 @@
 		<repository>
 			<id>wagon-git-releases</id>
 			<name>Synergian Releases</name>
-			<url>git:releases://git@github.com:synergian/wagon-git.git</url>
+			<url>git:releases://git@github.com:fritzprix/wagon-git.git</url>
 		</repository>
 		<snapshotRepository>
 			<id>wagon-git-snapshots</id>
 			<name>Synergian Snapshots</name>
-			<url>git:snapshots://git@github.com:synergian/wagon-git.git</url>
+			<url>git:snapshots://git@github.com:fritzprix/wagon-git.git</url>
 		</snapshotRepository>
 		<site>
 			<id>wagon-git-site</id>
 			<name>wagon-git Github Homepage</name>
-			<url>git:gh-pages://git@github.com:synergian/wagon-git.git</url>
+			<url>git:gh-pages://git@github.com:fritzprix/wagon-git.git</url>
 		</site>
 	</distributionManagement>
 

--- a/src/main/java/ar/com/synergian/wagongit/GitBackend.java
+++ b/src/main/java/ar/com/synergian/wagongit/GitBackend.java
@@ -17,6 +17,7 @@ public class GitBackend {
 	final File workDir;
 	private final String remote;
 	private final String branch;
+	final File copyDirectory;
 
 	private final ScmLogger log;
 
@@ -41,13 +42,17 @@ public class GitBackend {
 	};
 
 	public GitBackend(File workDir, String remote, String branch, ScmLogger log) throws GitException {
+		this(workDir, remote, branch, new File(workDir, "maven"), log);
+	}
+
+	public GitBackend(File workDir, String remote, String branch, File copyDirectory, ScmLogger log)  throws GitException  {
 		this.log = log;
 		this.remote = remote;
 		this.branch = branch;
 		this.workDir = workDir;
+		this.copyDirectory = copyDirectory;
 		if (!this.workDir.exists())
 			throw new GitException("Invalid directory");
-
 	}
 
 	private boolean run(String command) throws GitException {
@@ -186,7 +191,7 @@ public class GitBackend {
 
 	public void putDirectory(File sourceDirectory, String destinationDirectory) throws IOException {
 
-		FileUtils.copyDirectoryStructure(sourceDirectory, new File(workDir, destinationDirectory));
+		FileUtils.copyDirectoryStructure(sourceDirectory, new File(copyDirectory, destinationDirectory));
 
 	}
 }


### PR DESCRIPTION
- to be used as maven or gradle remote repository, the url should be pointing root directory for groupId sub-directory.
- unfortunately, some of bitbucket responds with 500 when try to access root directory of repository by raw content url.
- fix is done by adding subdirectory as a root directory for repository