### PR TITLE
Documentation update

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -2,5 +2,5 @@
 .container-fluid {
 	margin-right: auto;
 	margin-left: auto;
-	max-width: 1200px;
+	max-width: 100%;
 }

--- a/github.html
+++ b/github.html
@@ -4,296 +4,284 @@
  | Rendered using Apache Maven Fluido Skin 1.3.1
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="Date-Revision-yyyymmdd" content="20150415" />
-    <meta http-equiv="Content-Language" content="en" />
-    <title>wagon-git - </title>
-    <link rel="stylesheet" href="./css/apache-maven-fluido-1.3.1.min.css" />
-    <link rel="stylesheet" href="./css/site.css" />
-    <link rel="stylesheet" href="./css/print.css" media="print" />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="Date-Revision-yyyymmdd" content="20150415" />
+  <meta http-equiv="Content-Language" content="en" />
+  <title>wagon-git - </title>
+  <link rel="stylesheet" href="./css/apache-maven-fluido-1.3.1.min.css" />
+  <link rel="stylesheet" href="./css/site.css" />
+  <link rel="stylesheet" href="./css/print.css" media="print" />
+  <script type="text/javascript" src="./js/apache-maven-fluido-1.3.1.min.js"></script>
+</head>
 
-      
-    <script type="text/javascript" src="./js/apache-maven-fluido-1.3.1.min.js"></script>
-
-    
-                  </head>
-        <body class="topBarDisabled">
-          
-                
-                    
-    
-        <div class="container-fluid">
-          <div id="banner">
-        <div class="pull-left">
-                                <div id="bannerLeft">
-                <h2>wagon-git</h2>
-                </div>
-                      </div>
-        <div class="pull-right">  </div>
-        <div class="clear"><hr/></div>
+<body class="topBarDisabled">
+  <div class="container-fluid">
+    <div id="banner">
+      <div class="pull-left">
+        <div id="bannerLeft">
+          <h2>wagon-git</h2>
+        </div>
       </div>
+      <div class="pull-right">  </div>
+      <div class="clear"><hr/></div>
+    </div>
 
-      <div id="breadcrumbs">
-        <ul class="breadcrumb">
-                
-                    
-                  <li id="publishDate">Last Published: 2015-04-15
-                      <span class="divider">|</span>
-                   </li>
-                  <li id="projectVersion">Version: 0.2.5
-                      </li>
-                      
-                
-                    
-      
-                                    
-    <li class="pull-right">
-        <span class="divider">|</span>
-                      <a href="http://synergian.com.ar" class="externalLink" title="Synergian">
-        Synergian</a>
-      </li>
+    <div id="breadcrumbs">
+      <ul class="breadcrumb">
 
-  
-    <li class="pull-right">
-                      <a href="https://github.com/synergian/wagon-git" class="externalLink" title="GitHub Project Home">
-        GitHub Project Home</a>
-      </li>
 
-                    </ul>
-      </div>
+        <li id="publishDate">Last Published: 2015-04-15
+          <span class="divider">|</span>
+        </li>
+        <li id="projectVersion">Version: 0.2.5
+        </li>
 
-                  
-      <div class="row-fluid">
-        <div id="leftColumn" class="span2 affix affix-top">
-          <div class="well sidebar-nav">
-                
-                    
-                <ul class="nav nav-list">
-                    <li class="nav-header">wagon-git</li>
-                                                                                                  
-      <li>
-  
-                          <a href="index.html" title="Introduction">
-          <i class="icon-chevron-right"></i>
-        Introduction</a>
-                  </li>
-                                                                                                                        
-      <li>
-  
-                          <a href="usage.html" title="Basic configuration">
-          <i class="icon-chevron-right"></i>
-        Basic configuration</a>
-                  </li>
-                
-      <li class="active">
-  
-            <a href="#"><i class="none"></i>Github usage</a>
-          </li>
-                
-      <li>
-  
-                          <a href="bitbucket.html" title="Bitbucket usage">
-          <i class="none"></i>
-        Bitbucket usage</a>
+        <li class="pull-right">
+          <span class="divider">|</span>
+          <a href="http://synergian.com.ar" class="externalLink" title="Synergian">
+          Synergian</a>
+        </li>
+
+        <li class="pull-right">
+          <a href="https://github.com/synergian/wagon-git" class="externalLink" title="GitHub Project Home">
+          GitHub Project Home</a>
+        </li>
+
+      </ul>
+    </div>
+
+
+    <div class="row-fluid">
+      <div id="leftColumn" class="span2 affix affix-top">
+        <div class="well sidebar-nav">
+
+          <ul class="nav nav-list">
+            <li class="nav-header">wagon-git</li>
+
+            <li>
+              <a href="index.html" title="Introduction">
+                <i class="icon-chevron-right"></i>
+              Introduction</a>
             </li>
-                
-      <li>
-  
-                          <a href="troubleshooting.html" title="Troubleshooting">
-          <i class="none"></i>
-        Troubleshooting</a>
+
+            <li>
+              <a href="usage.html" title="Basic configuration">
+                <i class="icon-chevron-right"></i>
+              Basic configuration</a>
             </li>
-                
-      <li>
-  
-                          <a href="installation.html" title="Permanent Installation">
-          <i class="none"></i>
-        Permanent Installation</a>
+
+            <li class="active">
+              <a href="#"><i class="none"></i>Github usage</a>
             </li>
-                              <li class="nav-header">Project Documentation</li>
-                                                                                                                                                                                                                                                                                                        
-      <li>
-  
-                          <a href="project-info.html" title="Project Information">
-          <i class="icon-chevron-right"></i>
-        Project Information</a>
-                  </li>
-            </ul>
-                
-                    
-                
+
+            <li>
+              <a href="bitbucket.html" title="Bitbucket usage">
+                <i class="none"></i>
+              Bitbucket usage</a>
+            </li>
+
+            <li>
+              <a href="troubleshooting.html" title="Troubleshooting">
+                <i class="none"></i>
+              Troubleshooting</a>
+            </li>
+
+            <li>
+              <a href="installation.html" title="Permanent Installation">
+                <i class="none"></i>
+              Permanent Installation</a>
+            </li>
+            <li class="nav-header">Project Documentation</li>
+
+            <li>
+              <a href="project-info.html" title="Project Information">
+                <i class="icon-chevron-right"></i>
+              Project Information</a>
+            </li>
+          </ul>
+
+
+
           <hr />
 
-           <div id="poweredBy">
-                            <div class="clear"></div>
-                            <div class="clear"></div>
-                            <div class="clear"></div>
-                            <div class="clear"></div>
-                             <a href="http://maven.apache.org/" title="Built by Maven" class="poweredBy">
-        <img class="builtBy" alt="Built by Maven" src="./images/logos/maven-feather.png" />
-      </a>
-                  </div>
+          <div id="poweredBy">
+            <div class="clear"></div>
+            <div class="clear"></div>
+            <div class="clear"></div>
+            <div class="clear"></div>
+            <a href="http://maven.apache.org/" title="Built by Maven" class="poweredBy">
+              <img class="builtBy" alt="Built by Maven" src="./images/logos/maven-feather.png" />
+            </a>
           </div>
         </div>
-        
-                        
-        <div id="bodyColumn"  class="span10 offset3" >
-                                  
+      </div>
+
+
+      <div id="bodyColumn"  class="span10 offset3" >
+
+        <div class="section">
+          <h2>Configuring wagon-git for GitHub<a name="Configuring_wagon-git_for_GitHub"></a></h2>
+          <div class="section">
+            <h3>Configuring your distribution repositories<a name="Configuring_your_distribution_repositories"></a></h3>
             <div class="section">
-<h2>Configuring wagon-git for GitHub<a name="Configuring_wagon-git_for_GitHub"></a></h2>
-<div class="section">
-<h3>Configuring your distribution repositories<a name="Configuring_your_distribution_repositories"></a></h3>
-<div class="section">
-<h4>Adding a single repository for releases<a name="Adding_a_single_repository_for_releases"></a></h4>
-<div class="source">
-<pre>&lt;distributionManagement&gt;
+              <h4>Adding a single repository for releases<a name="Adding_a_single_repository_for_releases"></a></h4>
+              <div class="source">
+                <pre>
+&lt;distributionManagement&gt;
   &lt;repository&gt;
     &lt;id&gt;your-repo-id&lt;/id&gt;
     &lt;name&gt;Your Repo Name&lt;/name&gt;
     &lt;url&gt;git:releases://git@github.com:yourgithubusername/your-github-repo.git&lt;/url&gt;
   &lt;/repository&gt;
 &lt;/distributionManagement&gt;</pre></div></div>
-<div class="section">
-<h4>Adding a second repository for snapshot releases<a name="Adding_a_second_repository_for_snapshot_releases"></a></h4>
-<div class="source">
-<pre>&lt;distributionManagement&gt;
+              <div class="section">
+                <h4>Adding a second repository for snapshot releases<a name="Adding_a_second_repository_for_snapshot_releases"></a></h4>
+                <div class="source">
+                  <pre>
+&lt;distributionManagement&gt;
   &lt;repository&gt;
     &lt;id&gt;your-repo-id&lt;/id&gt;
     &lt;name&gt;Your Repo Name&lt;/name&gt;
     &lt;url&gt;git:releases://git@github.com:yourgithubusername/your-github-repo.git&lt;/url&gt;
   &lt;/repository&gt;
+  
   &lt;snapshotRepository&gt;
     &lt;id&gt;your-snapshot-repo-id&lt;/id&gt;
     &lt;name&gt;Your Snapshot Repo Name&lt;/name&gt;
     &lt;url&gt;git:snapshots://git@github.com:yourgithubusername/your-github-repo2.git&lt;/url&gt;
   &lt;/snapshotRepository&gt;
 &lt;/distributionManagement&gt;</pre></div></div>
-<div class="section">
-<h4>Adding a third repository for site deployment<a name="Adding_a_third_repository_for_site_deployment"></a></h4>
-<div class="source">
-<pre>&lt;distributionManagement&gt;
+              <div class="section">
+                <h4>Adding a third repository for site deployment<a name="Adding_a_third_repository_for_site_deployment"></a></h4>
+                <div class="source">
+                  <pre>
+&lt;distributionManagement&gt;
   &lt;repository&gt;
     &lt;id&gt;your-repo-id&lt;/id&gt;
     &lt;name&gt;Your Repo Name&lt;/name&gt;
     &lt;url&gt;git:releases://git@github.com:yourgithubusername/your-github-repo.git&lt;/url&gt;
   &lt;/repository&gt;
+
   &lt;snapshotRepository&gt;
     &lt;id&gt;your-snapshot-repo-id&lt;/id&gt;
     &lt;name&gt;Your Snapshot Repo Name&lt;/name&gt;
     &lt;url&gt;git:snapshots://git@github.com:yourgithubusername/your-github-repo2.git&lt;/url&gt;
   &lt;/snapshotRepository&gt;
+
   &lt;site&gt;
     &lt;id&gt;your-site-repo-id&lt;/id&gt;
     &lt;url&gt;git:site://git@github.com:yourgithubusername/your-github-repo2.git&lt;/url&gt;
   &lt;/site&gt;
 &lt;/distributionManagement&gt;</pre></div></div>
-<div class="section">
-<h4>Using <a class="externalLink" href="http://pages.github.com/">GitHub Pages</a> as a sites repository<a name="Using_GitHub_Pages_as_a_sites_repository"></a></h4>
-<p>Just use the <tt>gh-pages</tt> branch:</p>
-<div class="source">
-<pre>  ...
-  &lt;site&gt;
-    &lt;id&gt;your-site-repo-id&lt;/id&gt;
-    &lt;url&gt;git:gh-pages://git@github.com:yourgithubusername/your-github-repo2.git&lt;/url&gt;
-  &lt;/site&gt;
-  ...</pre></div></div></div>
-<div class="section">
-<h3>Consuming artifacts deployed in a GitHub repository<a name="Consuming_artifacts_deployed_in_a_GitHub_repository"></a></h3>
-<div class="section">
-<h4>Adding the repositories<a name="Adding_the_repositories"></a></h4>
-<div class="source">
-<pre>    ...
-        &lt;repositories&gt;
-            ...
-                &lt;repository&gt;
-                        &lt;id&gt;your-repo-id&lt;/id&gt;
-                        &lt;name&gt;Your Repo Name&lt;/name&gt;
-                        &lt;releases&gt;
-                                &lt;enabled&gt;true&lt;/enabled&gt;
-                        &lt;/releases&gt;
-                        &lt;snapshots&gt;
-                                &lt;enabled&gt;false&lt;/enabled&gt;
-                        &lt;/snapshots&gt;
-                        &lt;!-- 
-                           distributionManagement url was
-                           &lt;url&gt;git:your-branch://git@github.com:yourgithubusername/your-github-repo.git&lt;/url&gt;
-                        --&gt;
-                        &lt;url&gt;https://raw.github.com/yourgithubusername/your-github-repo.git/your-branch&lt;/url&gt;
-                &lt;/repository&gt;
-                ...</pre></div></div>
-<div class="section">
-<h4>Github Private Repositories<a name="Github_Private_Repositories"></a></h4>
-<p>Proceed the same way, but add basic authentication in your Maven settings.xml (usually located at your $MAVEN_HOME directory, check out <a class="externalLink" href="http://maven.apache.org/settings.html">http://maven.apache.org/settings.html</a> for a full guide).</p>
-<div class="source">
-<pre>&lt;settings&gt;
-        ...
-        &lt;servers&gt;
-                &lt;server&gt;
-                        &lt;id&gt;your-repo-id&lt;/id&gt;
-                        &lt;username&gt;yourgithubusername&lt;/username&gt;
-                        &lt;password&gt;yourgithubpassword&lt;/password&gt;
-                &lt;/server&gt;
-                ...
-        &lt;/servers&gt;
-        ...
-&lt;/settings&gt; </pre></div>
-<div class="section">
-<h5>Maven 2.2.1 Workaround for HTTP Basic auth<a name="Maven_2.2.1_Workaround_for_HTTP_Basic_auth"></a></h5>
-<p>Here's a workaround since HTTP basic authentication doesn't seem to be working with default https wagon provider (at least for maven 2.2.1).</p>
-<p>The workaround consists of injecting the basic authentication header, computing it manually as follows:</p>
-<div class="source">
-<pre>&lt;settings&gt;
-        ...
-        &lt;servers&gt;
-                &lt;server&gt;
-                        &lt;id&gt;your-repo-id&lt;/id&gt;
-                        &lt;configuration&gt;
-                                &lt;httpHeaders&gt;
-                                        &lt;property&gt;
-                                                &lt;name&gt;Authorization&lt;/name&gt;
-                                                &lt;value&gt;BASIC-AUTH HEADER VALUE&lt;/value&gt;
-                                        &lt;/property&gt;
-                                &lt;/httpHeaders&gt;
-                        &lt;/configuration&gt;
-                &lt;/server&gt;
-                ...
-        &lt;/servers&gt;
-        ...
-&lt;/settings&gt; </pre></div>
-<p>You can compute BASIC-AUTH HEADER VALUE with this bash script, for instance:</p>
-<div class="source">
-<pre>#!/bin/bash
-#
-# A small command that computes &quot;Authorization&quot; HTTP-header for basic
-# authentication.
+            <div class="section">
+              <h4>Using <a class="externalLink" href="http://pages.github.com/">GitHub Pages</a> as a sites repository<a name="Using_GitHub_Pages_as_a_sites_repository"></a></h4>
+              <p>Just use the <tt>gh-pages</tt> branch:</p>
+              <div class="source">
+                <pre>
+...
+&lt;site&gt;
+  &lt;id&gt;your-site-repo-id&lt;/id&gt;
+  &lt;url&gt;git:gh-pages://git@github.com:yourgithubusername/your-github-repo2.git&lt;/url&gt;
+&lt;/site&gt;
+...</pre></div></div></div>
+          <div class="section">
+            <h3>Consuming artifacts deployed in a GitHub repository<a name="Consuming_artifacts_deployed_in_a_GitHub_repository"></a></h3>
+            <div class="section">
+              <h4>Adding the repositories<a name="Adding_the_repositories"></a></h4>
+              <div class="source">
+                <pre>    
+...
+&lt;repositories&gt;
+...
+  &lt;repository&gt;
+    &lt;id&gt;your-repo-id&lt;/id&gt;
+    &lt;name&gt;Your Repo Name&lt;/name&gt;
+    &lt;releases&gt;
+      &lt;enabled&gt;true&lt;/enabled&gt;
+    &lt;/releases&gt;
+    &lt;snapshots&gt;
+      &lt;enabled&gt;false&lt;/enabled&gt;
+    &lt;/snapshots&gt;
+    &lt;!-- distributionManagement url was &lt;url&gt;git:your-branch://git@github.com:yourgithubusername/your-github-repo.git&lt;/url&gt; --&gt;
+    &lt;url&gt;https://raw.github.com/yourgithubusername/your-github-repo.git/your-branch&lt;/url&gt;
+  &lt;/repository&gt;
+...</pre></div></div>
+              <div class="section">
+                <h4>Github Private Repositories<a name="Github_Private_Repositories"></a></h4>
 
-read -p &quot;Username: &quot; username
-read -s -p &quot;Password: &quot; password
-echo &quot;&quot;
-encoded=`echo -n &quot;$username:$password&quot; | base64`
-echo &quot;Basic $encoded&quot;</pre></div>
-<p>Notice that the value is NOT a hash value, it's the Base-64 encoded value of your password. Don't publish it. </p></div></div></div></div>
-                  </div>
+                <h5>Auth with Username and Password<a name="Auth with Username and Password"></a></h5>
+                <p>Proceed the same way, but add basic authentication in your Maven settings.xml (usually located at your $MAVEN_HOME directory, check out <a class="externalLink" href="http://maven.apache.org/settings.html">http://maven.apache.org/settings.html</a> for a full guide).</p>
+                <div class="source">
+                  <pre>
+&lt;settings&gt;
+  ...
+  &lt;servers&gt;
+    &lt;server&gt;
+      &lt;id&gt;your-repo-id&lt;/id&gt;
+      &lt;username&gt;yourgithubusername&lt;/username&gt;
+      &lt;password&gt;yourgithubpassword&lt;/password&gt;
+    &lt;/server&gt;
+  ...
+  &lt;/servers&gt;
+...
+&lt;/settings&gt; </pre>
+                </div>
+
+
+                <div class="section">
+                  <h5>Auth with Access Token<a name="Auth with Access Token"></a></h5>
+                  <p>
+                    When using an access token, the Github V3 API expects that the token be in the Authorization header as a bearer token. 
+                  </p>
+
+                  <div class="source">
+                    <pre>
+&lt;settings&gt;
+  ...
+  &lt;servers&gt;
+    &lt;server&gt;
+    &lt;id&gt;your-repo-id&lt;/id&gt;
+    &lt;configuration&gt;
+      &lt;httpHeaders&gt;
+        &lt;property&gt;
+          &lt;name&gt;Authorization&lt;/name&gt;
+          &lt;value&gt;Bearer ${github.accesstoken}&lt;/value&gt;
+        &lt;/property&gt;
+      &lt;/httpHeaders&gt;
+    &lt;/configuration&gt;
+    &lt;/server&gt;
+  ...
+  &lt;/servers&gt;
+  ...
+&lt;/settings&gt;</pre></div>
+
+                <p>
+                  You can put your access token directly where ${github.accesstoken} is, or you can pass it explicitly when running maven.
+                </p>
+                <div class="source">
+                  <pre>mvn -Dgithub.accesstoken=YOUR_ACCESS_TOKEN dependency:resolve -U</pre></div>
+              </div>
+
+
+
+
             </div>
           </div>
-
-    <hr/>
-
-    <footer>
-            <div class="container-fluid">
-                      <div class="row-fluid">
-                                        <p class="pull-right">Copyright &copy;                    2011&#x2013;2015
-                        <a href="http://synergian.com.ar">Synergian</a>.
-            All rights reserved.      
-                    
-      </p>
         </div>
+      </div>
+    </div>
+  </div>
 
-        
-        
-                </div>
-    </footer>
-        </body>
+  <hr/>
+
+  <footer>
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <p class="pull-right">Copyright &copy; 2011&#x2013;2015 <a href="http://synergian.com.ar">Synergian</a>. All rights reserved. </p>
+      </div>
+    </div>
+  </footer>
+</body>
 </html>


### PR DESCRIPTION
Added documentation to explain how to use Github access tokens with this wagon.  Github API V3 has changed the way that authentication works with access tokens.

Instruction summary:
### **Github Auth with Access Token**

When using an access token, the Github V3 API expects that the token be in the Authorization header as a bearer token.  Add server entries into your settings.xml file like this:

```
<settings>
  ...
  <servers>
    <server>
    <id>your-repo-id</id>
    <configuration>
      <httpHeaders>
        <property>
          <name>Authorization</name>
          <value>Bearer ${github.accesstoken}</value>
        </property>
      </httpHeaders>
    </configuration>
    </server>
  ...
  </servers>
  ...
</settings>
```